### PR TITLE
docs: recommend replacement firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-> **pixoo-bridge has been superseded by [pixoo-bridge.rs](https://github.com/simplyRoba/pixoo-bridge.rs)** — a drop-in replacement written in Rust. Same HTTP API, ~2 MB RAM instead of ~200 MB. See the [migration guide](https://github.com/simplyRoba/pixoo-bridge.rs#migration) for details.   
+> [!IMPORTANT]
+> **This Kotlin bridge has been superseded. Choose the replacement that matches
+> your device:**
+>
+> - **Keep the original firmware:** use
+>   [pixoo-bridge.rs](https://github.com/simplyRoba/pixoo-bridge.rs), the
+>   drop-in Rust replacement with the same HTTP API, using approximately 2 MB of
+>   RAM instead of 200 MB. See its
+>   [migration guide](https://github.com/simplyRoba/pixoo-bridge.rs#migration).
+> - **Replace the mainboard firmware:** use
+>   [pixoo-firmware](https://github.com/simplyRoba/pixoo-firmware) for a fully
+>   local ESPHome and Home Assistant setup without the Divoom app or cloud.
 
 # Pixoo Bridge
+
 Small docker image to communicate with a network enabled pixoo LED dot matrix.
 
 <!-- TODO Downloads from ghcr.io -->


### PR DESCRIPTION
## Summary

- point Pixoo64 users to the fully local replacement firmware
- clarify that this bridge remains useful when stock firmware must stay installed

## Validation

- documentation-only change
- Markdown diff checked